### PR TITLE
TrainHtrPlus removes old .pb files. fixes CITlabRostock/CITlabModule#1

### DIFF
--- a/src/main/java/de/uros/citlab/module/util/MetadataUtil.java
+++ b/src/main/java/de/uros/citlab/module/util/MetadataUtil.java
@@ -39,7 +39,7 @@ public class MetadataUtil {
     }
 
     public static String getSoftwareVersion() {
-        return "2.4.1";
+        return "2.4.2";
     }
 
 }


### PR DESCRIPTION
Latest .pb file is identified by `File::lastModified()` and all others are removed. 